### PR TITLE
Add buffer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const identityPreimageHex = "0x8c4e6301fba207fb2375d2fda9f2ebe1142d07d1954d871e2
 const sigmaHex = "0x312c10b186086d502ba683cffc2ae650d53b508904b3c430df8e7d5aa336c0f5";
 
 // Call encryptData function
-const encryptedData = await encryptData(msgHex, eonKeyHex, identityPreimageHex, sigmaHex);
+const encryptedData = await encryptData(msgHex, identityPreimageHex, eonKeyHex, sigmaHex);
 console.log("Encryption successful:", encryptedData);
 ``` 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "shutter-sdk",
+  "name": "@shutter-network/shutter-sdk",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shutter-sdk",
+      "name": "@shutter-network/shutter-sdk",
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "browser-or-node": "^3.0.0",
+        "buffer": "^6.0.3",
         "lodash": "^4.17.21",
         "viem": "^2.23.2"
       },
@@ -2047,6 +2048,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2124,6 +2145,30 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -2927,6 +2972,26 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "browser-or-node": "^3.0.0",
+    "buffer": "^6.0.3",
     "lodash": "^4.17.21",
     "viem": "^2.23.2"
   },

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { hexToBytes, keccak256, bytesToBigInt, bytesToHex, numberToBytes } from 'viem';
 import pkg from 'lodash';
 const { zip } = pkg;


### PR DESCRIPTION
This is necessary because `Buffer` is not automatically available in browser environments.

Also, small fix in the readme.